### PR TITLE
Fixed #6 reported by @cesag

### DIFF
--- a/bxpress/sql/mysql.sql
+++ b/bxpress/sql/mysql.sql
@@ -56,8 +56,7 @@ CREATE TABLE `mod_bxpress_forums` (
   `attach_ext` text NOT NULL,
   `subforums` int(10) NOT NULL default '0',
   `permissions` text NOT NULL,
-  PRIMARY KEY  (`id_forum`),
-  UNIQUE KEY `friendname` (`friendname`)
+  PRIMARY KEY  (`id_forum`)
 ) ENGINE=InnoDB;
 
 CREATE TABLE `mod_bxpress_likes` (

--- a/bxpress/xoops_version.php
+++ b/bxpress/xoops_version.php
@@ -153,7 +153,8 @@ $modversion = array(
         'mod_bxpress_posts',
         'mod_bxpress_posts_text',
         'mod_bxpress_report',
-        'mod_bxpress_topics'
+        'mod_bxpress_topics',
+        'mod_bxpress_likes'
     ),
 
     // Smarty templates


### PR DESCRIPTION
Fixed issue that prevents bxpress to be installed.
Added likes table to tables list in xoops_version.php
